### PR TITLE
Generate function to return a slice of filenames

### DIFF
--- a/template/files.go
+++ b/template/files.go
@@ -153,4 +153,11 @@ func {{exportedTitle "WriteFile"}}(filename string, data []byte, perm os.FileMod
   return err
 }
 
+// FileNames is a list of files included in this filebox
+var {{exportedTitle "FileNames"}} = []string {
+  {{range .Files}}
+  "{{.Path}}",
+  {{end}}
+}
+
 `


### PR DESCRIPTION
The same as `AssetNames` function in `go-bindata`.

My use case is compiling templates inside the file:

```go
for _, filename := range filebox.FileNames() {
    data, err := filebox.ReadFile(filename)
    if err != nil {
        log.Fatal(err)
    }
    // compile template file here
}
```