### PR TITLE
Add a debug mode

### DIFF
--- a/_example/simple/b0x.json
+++ b/_example/simple/b0x.json
@@ -76,6 +76,12 @@
   // default: false
   "spread": false,
 
+  // [debug] is a debug mode where the files are read directly from the file
+  // sytem. Useful for web dev when files change when the server is running.
+  // type: bool
+  // default: false
+  "debug": false,
+
   // type: array of objects
   "custom": [
     {

--- a/_example/simple/b0x.yaml
+++ b/_example/simple/b0x.yaml
@@ -71,6 +71,12 @@ unexporTed: false
 # default: false
 spread: false
 
+# [debug] is a debug mode where the files are read directly from the file
+# sytem. Useful for web dev when files change when the server is running.
+# type: bool
+# default: false
+debug: false
+
 # type: array of objects
 custom:
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Spread     bool
 	Unexported bool
 	Clean      bool
+	Debug      bool
 }
 
 // Defaults set the default value for some variables

--- a/main.go
+++ b/main.go
@@ -73,12 +73,14 @@ func main() {
 		Spread      bool
 		DirList     []string
 		Compression *compression.Options
+		Debug       bool
 	}{
 		Pkg:         cfg.Pkg,
 		Files:       files,
 		Spread:      cfg.Spread,
 		DirList:     dirs.Clean(),
 		Compression: cfg.Compression,
+		Debug:       cfg.Debug,
 	}
 	tmpl, err := t.Exec()
 	if err != nil {

--- a/template/files.go
+++ b/template/files.go
@@ -26,7 +26,7 @@ var {{exportedTitle "HTTP"}} http.FileSystem = new({{exported "HTTPFS"}})
 // HTTPFS implements http.FileSystem
 type {{exported "HTTPFS"}} struct {}
 
-{{if not .Spread}}
+{{if (and (not .Spread) (not .Debug))}}
 {{range .Files}}
 // {{exportedTitle "File"}}{{buildSafeVarName .Path}} is a file
 var {{exportedTitle "File"}}{{buildSafeVarName .Path}} = {{.Data}}
@@ -44,7 +44,7 @@ func init() {
   {{end}}
 {{end}}
 
-{{if not .Spread}}
+{{if (and (not .Spread) (not .Debug))}}
   var f webdav.File
   {{if $Compression.Compress}}
   {{if not $Compression.Keep}}
@@ -103,7 +103,7 @@ func init() {
 
 // Open a file
 func (hfs *{{exported "HTTPFS"}}) Open(path string) (http.File, error) {
-  f, err := {{exported "FS"}}.OpenFile(path, os.O_RDONLY, 0644)
+  f, err := {{if .Debug}}os{{else}}{{exported "FS"}}{{end}}.OpenFile(path, os.O_RDONLY, 0644)
   if err != nil {
     return nil, err
   }
@@ -113,7 +113,7 @@ func (hfs *{{exported "HTTPFS"}}) Open(path string) (http.File, error) {
 
 // ReadFile is adapTed from ioutil
 func {{exportedTitle "ReadFile"}}(path string) ([]byte, error) {
-  f, err := {{exported "FS"}}.OpenFile(path, os.O_RDONLY, 0644)
+  f, err := {{if .Debug}}os{{else}}{{exported "FS"}}{{end}}.OpenFile(path, os.O_RDONLY, 0644)
   if err != nil {
     return nil, err
   }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -40,6 +40,7 @@ func TestTemplate(t *testing.T) {
 		Spread      bool
 		DirList     []string
 		Compression *compression.Options
+		Debug       bool
 	}{
 		Pkg:         "main",
 		Files:       files,


### PR DESCRIPTION
This mode always reads right from the file system. For webdev it's a real pain to have to keep building the project just to change a javascript file.

I think I got all the places where it would read but left write so writing to the memory file system would still work. This would break if the user read directly from the file vars.