### PR TITLE
Fix execution on some environments: os.Args[0] is not the current directory

### DIFF
--- a/config/file.go
+++ b/config/file.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/UnnoTed/fileb0x/utils"
 
@@ -55,16 +54,6 @@ func (f *File) FromArg(read bool) error {
 	// check if extension is json, yaml or toml
 	// then get it's absolute path
 	if ext == "json" || ext == "yaml" || ext == "yml" || ext == "toml" {
-		abs := filepath.IsAbs(arg)
-		if !abs {
-			dir, err := utils.GetCurrentDir()
-			if err != nil {
-				return err
-			}
-
-			arg = filepath.Clean(dir + "/" + arg)
-		}
-
 		f.FilePath = arg
 
 		// so we can test without reading a file


### PR DESCRIPTION
Go can understand relative paths. No need to convert to absolute.

EDIT: just to explain.

A command like this:

```sh
fileb0x mybox.yaml
```

Woks on `cmd` on Windows, but not on Git bash, because the command will to converted to:

```
C:\<...>\GOPATH\bin\fileb0x.exe mybox.yaml
```

So it returns an error like this:

> 2017/03/04 15:29:01 Error: I Can't find the config file at [C:\<...>GOPATH\bin\fileb0x_templates.yaml]

This is because `os.Args[0]` constains the executable path, not the  working directory.

An alternative would be using [`os.Getwd()`](https://golang.org/pkg/os/#Getwd), but Go does that automatically.