### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,5 +79,13 @@ func (cfg *Config) Defaults() error {
 		}
 	}
 
+	if cfg.Compression == nil {
+		cfg.Compression = &compression.Options{
+			Compress: false,
+			Method: "DefaultCompression",
+			Keep: false,
+		}
+	}
+
 	return nil
 }

--- a/config/file.go
+++ b/config/file.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"gopkg.in/yaml.v2"
+	"fmt"
 )
 
 // File holds config file info
@@ -74,19 +75,17 @@ func (f *File) Parse() (*Config, error) {
 	// remove comments
 	f.RemoveJSONComments()
 
-	var to *Config
-	var err error
-
-	// parse file
-	if f.Mode == "json" {
-		err = json.Unmarshal(f.Data, &to)
-	} else if f.Mode == "yaml" || f.Mode == "yml" {
-		err = yaml.Unmarshal(f.Data, &to)
-	} else if f.Mode == "toml" {
-		err = toml.Unmarshal(f.Data, &to)
+	to := &Config{}
+	switch f.Mode {
+	case "json":
+		return to, json.Unmarshal(f.Data, to)
+	case "yaml", "yml":
+		return to, yaml.Unmarshal(f.Data, to)
+	case "toml":
+		return to, toml.Unmarshal(f.Data, to)
+	default:
+		return nil, fmt.Errorf("unknown mode '%s'", f.Mode)
 	}
-
-	return to, err
 }
 
 // Load the json/yaml file that was specified from args

--- a/main.go
+++ b/main.go
@@ -123,11 +123,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// create dest folder when it doesn't exists
-	if !utils.Exists(cfg.Dest) {
-		if err := os.MkdirAll(cfg.Dest, 0770); err != nil {
-			log.Fatal(err)
-		}
+	if err := os.MkdirAll(cfg.Dest, 0770); err != nil {
+		log.Fatal(err)
 	}
 
 	// gofmt

--- a/main.go
+++ b/main.go
@@ -125,8 +125,7 @@ func main() {
 
 	// create dest folder when it doesn't exists
 	if !utils.Exists(cfg.Dest) {
-		err = os.MkdirAll(cfg.Dest, 0777)
-		if err != nil {
+		if err := os.MkdirAll(cfg.Dest, 0770); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -140,7 +139,7 @@ func main() {
 	}
 
 	// write final execuTed template into the destination file
-	err = ioutil.WriteFile(cfg.Dest+cfg.Output, tmpl, 0777)
+	err = ioutil.WriteFile(cfg.Dest+cfg.Output, tmpl, 0640)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -199,8 +198,7 @@ func main() {
 			}
 
 			// write final execuTed template into the destination file
-			err = ioutil.WriteFile(cfg.Dest+customName, tmpl, 0777)
-			if err != nil {
+			if err := ioutil.WriteFile(cfg.Dest+customName, tmpl, 0640); err != nil {
 				log.Fatal(err)
 			}
 		}


### PR DESCRIPTION
I was trying to use fileb0x on a project (running: `fileb0x files.yml`) but it was segfaulting:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x716116]

goroutine 1 [running]:
github.com/UnnoTed/fileb0x/config.(*Config).Defaults(0x0, 0x0, 0x0)
	/home/opalmer/go/src/github.com/UnnoTed/fileb0x/config/config.go:35 +0x26
main.main()
	/home/opalmer/go/src/github.com/UnnoTed/fileb0x/main.go:65 +0x24d
```

I was able to fix this with the changes in this PR and also fixed a couple of other issues I noticed along the way. 

The underlying problem was that `Parse()` was returning nil instead of a pointer to `Config`. This happened because the original code did:

```golang
var to *Config
err = json.Unmarshal(f.Data, &to)
```

Unfortunately fileb0x is still broken for me but this PR should at least fix the panic described above.
```
$ fileb0x ./defaults.yml 
panic: open /ab0x.go: permission denied

goroutine 1 [running]:
main.main()
	/home/opalmer/go/src/github.com/UnnoTed/fileb0x/main.go:146 +0x1a59
```
*NOTE* The above is a panic I introduced so I could show the line it's occurring on. `log.Fatal()` normally hides this information.