### PR TITLE
Add option to disable prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _example/simple/static/
 _example/echo/myEmbeddedFiles/
+fileb0x

--- a/_example/simple/b0x.json
+++ b/_example/simple/b0x.json
@@ -87,6 +87,11 @@
   // default: ab0x.go
   "output": "ab0x.go",
 
+  // [noprefix] disables adding "a" prefix to output
+  // type: bool
+  // default: false
+  "noprefix": false
+
   // [unexporTed] builds non-exporTed functions, variables and types...
   // type: bool
   // default: false

--- a/_example/simple/b0x.toml
+++ b/_example/simple/b0x.toml
@@ -81,6 +81,11 @@ clean = false
 # default: ab0x.go
 output = "ab0x.go"
 
+# [noprefix] disables adding "a" prefix to output
+# type: bool
+# default: false
+noprefix = false
+
 # [unexporTed] builds non-exporTed functions, variables and types...
 # type: bool
 # default: false

--- a/_example/simple/b0x.yaml
+++ b/_example/simple/b0x.yaml
@@ -81,6 +81,11 @@ clean: false
 # default: ab0x.go
 output: "ab0x.go"
 
+# [noprefix] disables adding "a" prefix to output
+# type: bool
+# default: false
+noprefix: false
+
 # [unexporTed] builds non-exporTed functions, variables and types...
 # type: bool
 # default: false

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,9 @@ import (
 
 // Config holds the json/yaml/toml data
 type Config struct {
-	Dest        string
+	Dest     string
+	NoPrefix bool
+
 	Pkg         string
 	Fmt         bool // gofmt
 	Compression *compression.Options
@@ -52,7 +54,7 @@ func (cfg *Config) Defaults() error {
 
 	// inserts an A before the output file's name so it can
 	// run init() before b0xfile's
-	if !strings.HasPrefix(cfg.Output, "a") {
+	if !cfg.NoPrefix && !strings.HasPrefix(cfg.Output, "a") {
 		cfg.Output = "a" + cfg.Output
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,12 +13,14 @@ func TestConfigDefaults(t *testing.T) {
 		{Dest: "", Pkg: "", Output: ""},
 		{Dest: "hello", Pkg: "static", Output: "ssets"},
 		{Dest: "hello", Pkg: "static", Output: "amissingEnd"},
+		{Dest: "hello", Pkg: "static", Output: "compiled", NoPrefix: true},
 	}
 
 	expecTedList := []*Config{
 		{Dest: "/", Pkg: "main", Output: "ab0x.go"},
 		{Dest: "hello/", Pkg: "static", Output: "assets.go"},
 		{Dest: "hello/", Pkg: "static", Output: "amissingEnd.go"},
+		{Dest: "hello/", Pkg: "static", Output: "compiled.go", NoPrefix: true},
 	}
 
 	for i, cfg := range cfgList {


### PR DESCRIPTION
Hello! Awesome library, am currently looking into using this as a replacement to go-bindata 😁 

Right now, output files will always have the `a` prefix, and while I can see why, I think it'd be nice to have the option to disable this (in my case, I want it compiled to a file called `compiled.go`). This PR adds an option (`false` by default) to disable this behaviour.

I would be happy to make any changes @UnnoTed if you deem them necessary, and thanks your work!