### PR TITLE
Added Init config variable.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	Debug      bool
 	Updater    updater.Config
 	Lcf        bool
+
+	Init string
 }
 
 // Defaults set the default value for some variables
@@ -69,6 +71,10 @@ func (cfg *Config) Defaults() error {
 			Method:   "DefaultCompression",
 			Keep:     false,
 		}
+	}
+
+	if cfg.Init == "" {
+		cfg.Init = "init"
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ func main() {
 			Debug            bool
 			Updater          updater.Config
 			ModificationHash string
+			Init             string
 		}{
 			ConfigFile:       filepath.Base(cfgPath),
 			Now:              time.Now().String(),
@@ -158,6 +159,7 @@ func main() {
 			Debug:            cfg.Debug,
 			Updater:          cfg.Updater,
 			ModificationHash: modHash,
+			Init:             cfg.Init,
 		}
 
 		tmpl, err := t.Exec()

--- a/template/file.go
+++ b/template/file.go
@@ -20,7 +20,7 @@ import (
 // {{exportedTitle "File"}}{{buildSafeVarName .Path}} is "{{.Path}}"
 var {{exportedTitle "File"}}{{buildSafeVarName .Path}} = {{.Data}}
 
-func init() {
+func {{ .Init}}() {
   {{if .Compression.Compress}}
   {{if not .Compression.Keep}}
   rb := bytes.NewReader({{exportedTitle "File"}}{{buildSafeVarName .Path}})

--- a/template/files.go
+++ b/template/files.go
@@ -31,7 +31,7 @@ import (
 {{end}}
 )
 
-var ( 
+var (
   // CTX is a context for webdav vfs
   {{exported "CTX"}} = context.Background()
 
@@ -62,7 +62,7 @@ var {{exportedTitle "File"}}{{buildSafeVarName .Path}} = {{.Data}}
 {{end}}
 {{end}}
 
-func init() {
+func {{ .Init}}() {
   err := {{exported "CTX"}}.Err()
   if err != nil {
 		panic(err)
@@ -232,7 +232,7 @@ func {{exportedTitle "WalkDirs"}}(name string, includeDirsInList bool, files ...
 	if err != nil {
     return nil, err
   }
-  
+
   err = f.Close()
   if err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ type {{exportedTitle "Server"}} struct {
   Files []string
 }
 
-// Init sets the routes and basic http auth 
+// Init sets the routes and basic http auth
 // before starting the http server
 func (s *{{exportedTitle "Server"}}) Init() {
   s.Auth = {{exportedTitle "Auth"}}{
@@ -301,7 +301,7 @@ func (s *{{exportedTitle "Server"}}) Init() {
 // Get gives a list of file names and hashes
 func (s *{{exportedTitle "Server"}}) Get(c echo.Context) error {
   log.Println("[fileb0x.Server]: Hashing server files...")
-  
+
   // file:hash
   hashes := map[string]string{}
 
@@ -335,7 +335,7 @@ func (s *{{exportedTitle "Server"}}) Get(c echo.Context) error {
   })
 }
 
-// Post is used to upload a file and replace 
+// Post is used to upload a file and replace
 // it in the virtual memory file system
 func (s *{{exportedTitle "Server"}}) Post(c echo.Context) error {
   file, err := c.FormFile("file")
@@ -358,7 +358,7 @@ func (s *{{exportedTitle "Server"}}) Post(c echo.Context) error {
     log.Println("[fileb0x.Server]: Creating dir tree", newDir)
     list := strings.Split(newDir, "/")
     var tree string
-    
+
     for _, dir := range list {
       if dir == "" || dir == "." || dir == "/" || dir == "./" {
         continue
@@ -392,7 +392,7 @@ func (s *{{exportedTitle "Server"}}) Post(c echo.Context) error {
   return c.String(http.StatusOK, "ok")
 }
 
-// BasicAuth is a middleware to check if 
+// BasicAuth is a middleware to check if
 // the username and password are valid
 // echo's middleware isn't used because of golint issues
 func (s *{{exportedTitle "Server"}}) BasicAuth() echo.MiddlewareFunc {


### PR DESCRIPTION
When the config file specifies the Init option, the initialization
function will be named that (by default it is init() ).

Users can specify an exported name which needs to be explicitly
called. This allows initialization to be explicit to avoid doing it in
cases where it is not needed.