### PR TITLE
fix #47: update godirwalk to v1.7.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bmatcuk/doublestar v1.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/karrick/godirwalk v1.7.3
+	github.com/karrick/godirwalk v1.7.4
 	github.com/labstack/echo v3.2.1+incompatible
 	github.com/labstack/gommon v0.2.7 // indirect
 	github.com/maruel/panicparse v1.1.1 // indirect


### PR DESCRIPTION
godirwalk 1.7.3 fails with a bad checksum on some systems (Windows, some CircleCI builds)

updating to v1.7.4 fixes the issue